### PR TITLE
Serverless variables for region are not properly resolved in the plugin's constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ class ServerlessKmsGrants {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    this.kms = new aws.KMS({ region: this.serverless.service.provider.region });
+    this.kms = null;
 
     this.commands = {
       createKmsGrant: {
@@ -36,6 +36,11 @@ class ServerlessKmsGrants {
   }
 
   async createGrant() {
+
+    if (!this.kms) {
+      this.kms = new aws.KMS({ region: this.serverless.service.provider.region });
+    }
+
     const grants = _.get(this.serverless.service, "custom.kmsGrants");
 
     if (!grants) {
@@ -62,6 +67,11 @@ class ServerlessKmsGrants {
   }
 
   async revokeGrant() {
+
+    if (!this.kms) {
+      this.kms = new aws.KMS({ region: this.serverless.service.provider.region });
+    }
+
     const grants = _.get(this.serverless.service, "custom.kmsGrants");
 
     if (!grants) {


### PR DESCRIPTION
**Problem**
When using a variable for region in the serverless config, (i.e. `region: ${opt:region, 'us-east-2'}`),  serverless doesn't resolve that variable before calling the plugin's constructor. This causes the aws.KMS(...), inside the constructor, to fail with an "Invalid Region". 

**Solution**
This code change solves this problem by initializing AWS lazily inside both `createGrant` and `revokeGrant`

Please let me know if you have any questions!


